### PR TITLE
Creating default object from empty value 문제

### DIFF
--- a/ncenterlite.model.php
+++ b/ncenterlite.model.php
@@ -121,6 +121,7 @@ class ncenterliteModel extends ncenterlite
 			$member_srl = $logged_info->member_srl;
 		}
 
+		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$args->page = $page ? $page : 1;
 		if($readed) $args->readed = $readed;


### PR DESCRIPTION
PHP 5.4.x 이상 환경에서

Warning: Creating default object from empty value in XE_PATH\modules\ncenterlite\ncenterlite.model.php on line 124

라고 나오는 문제입니다. :smile: 
