### PR TITLE
z-index 설정의 누락된 type 속성 추가

### DIFF
--- a/tpl/Config.html
+++ b/tpl/Config.html
@@ -142,7 +142,7 @@
 		<div class="x_control-group">
 			<label class="x_control-label">알림센터의 z-index</label>
 			<div class="x_controls">
-				<input name="zindex" value="{$config->zindex}" />
+				<input type="number" name="zindex" value="{$config->zindex}" />
 				<p class="x_help-block">알림센터가 다른 요소에 가려지는 경우에 100, 200, ... 이상으로 높여 보세요.</p>
 			</div>
 		</div>


### PR DESCRIPTION
type 속성이 누락되어 CSS가 적용되지 않는 문제를 해결합니다
