### PR TITLE
익명 알림에서 익명 이름설정 input의 빠진 type 추가

### DIFF
--- a/tpl/Config.html
+++ b/tpl/Config.html
@@ -22,7 +22,7 @@
 		<div class="x_control-group">
 			<label class="x_control-label">익명 알림에서 익명 이름 설정</label>
 			<div class="x_controls">
-				<input name="anonymous_name" value="{$config->anonymous_name}" />
+				<input type="text" name="anonymous_name" value="{$config->anonymous_name}" />
 				<p class="x_help-block">익명 게시판 등에서 알림이 등록될 시, Anonymous 등 익명을 표시할 이름을 설정할 수 있습니다. 기본은 Anonymous 입니다.</p>
 			</div>
 		</div>


### PR DESCRIPTION
type이 빠져서 CSS가 적용되지 않는 문제점이 있습니다
