### PR TITLE
댓글을 표시할 필요가 없을 경우 스크립트 실행을 하지 않게 수정.

### DIFF
--- a/tpl/js/ncenterlite.js
+++ b/tpl/js/ncenterlite.js
@@ -24,7 +24,7 @@ function ncenterlite_highlight() {
 		}
 
 		var s = decodeURIComponent(location.href).replace(/.*#comment_/,'');
-		if(!s) return;
+		if(!s || s === decodeURIComponent(location.href)) return;
 		s = 'comment_' + s;
 		jQuery('.xe_content').each(function(){
 			var t = jQuery(this);


### PR DESCRIPTION
https://github.com/xe-public/xe-module-ncenterlite/issues/88
댓글이 없을 경우, 페이지 주소가 모두 입력되어 정규식 오류를 일으킬 수 있다.