### PR TITLE
알림센터 다국어 지원 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ XpressEngine(XE) Notification Center *Lite*
 [![Latest release](http://img.shields.io/github/release/xe-public/xe-module-ncenterlite.svg)](https://github.com/xe-public/xe-module-ncenterlite/releases)
 [![License](http://img.shields.io/badge/license-GPL%20v2-brightgreen.svg)](http://www.gnu.org/licenses/gpl.html)
 
+한국어 설명
+---
 XE 알림센터의 무료 버전.
 
 개요
 ---
 이 소프트웨어는 'XE 알림센터'의 무료 버전의 모듈입니다.
 
-이 소프트웨어는 GPL GPL을 채택한 오픈 소스 소프트웨어(OSS)로써 자유롭게 사용할 수 있는 자유 소프트웨어입니다. 이 라이선스의 조건을 준수하는 조건하에 누구나 자유롭게 사용할 수 있으며 개작 할 수 있습니다.
+이 소프트웨어는 GPL 을 채택한 오픈 소스 소프트웨어(OSS)로써 자유롭게 사용할 수 있는 자유 소프트웨어입니다. 이 라이선스의 조건을 준수하는 조건하에 누구나 자유롭게 사용할 수 있으며 개작 할 수 있습니다.
 
 기능
 ---
@@ -18,6 +20,26 @@ XE 알림센터의 무료 버전.
 * '@닉네임'과 같은 형태로 지정한 회원에게 알림
 	* '@아이디'와 같은 형태로도 지정한 회원에게 알림기능가능(설정요망)
 * 회원이 모든 알림 내용을 받거나 안받을 수 있도록 설정가능.(회원설정가능)
+
+
+English description
+---
+Free version of XE Notification Center
+
+Overview
+---
+This software is the free version of 'XE Notification Center'.
+
+This software is distributed under the terms of GPL, and it is open-source software so that you can use this software freely. Under the terms of GPL, everyone can copy, distribute and/or modify this software.
+
+Functions
+---
+* Comment notification to the original document author, after a reply written.
+* Comment notification to the original comment author, after a reply to the comment written.
+* '@Nickname' form notificaiton 과 같은 형태로 지정한 회원에게 알림
+	* '@ID' form may be used to notice (settings required)
+* Each members can control their notification settings. (each member can control)
+
 
 Maintainers
 ------
@@ -31,7 +53,8 @@ Contributors
 [@kantsoft](http://github.com/kantsoft),
 [@hansim](https://github.com/hansim),
 [@SeungYeonYou](https://github.com/SeungYeonYou),
-[@YJSoft](https://github.com/YJSoft)
+[@YJSoft](https://github.com/YJSoft),
+[@misol](https://github.com/misol)
 
 Thanks to
 ---------

--- a/lang/lang.xml
+++ b/lang/lang.xml
@@ -20,10 +20,130 @@
 		<value xml:lang="en"><![CDATA[message]]></value>
 		<value xml:lang="jp"><![CDATA[メッセージ]]></value>
 	</item>
+	<item name="ncenterlite_sender">
+		<value xml:lang="ko"><![CDATA[보낸 사람]]></value>
+		<value xml:lang="en"><![CDATA[Sender]]></value>
+		<value xml:lang="jp"><![CDATA[Sender]]></value>
+	</item>
+	<item name="ncenterlite_addressee">
+		<value xml:lang="ko"><![CDATA[받는 사람]]></value>
+		<value xml:lang="en"><![CDATA[Addressee]]></value>
+		<value xml:lang="jp"><![CDATA[Addressee]]></value>
+	</item>
+	<item name="ncenterlite_noti_contents">
+		<value xml:lang="ko"><![CDATA[내용]]></value>
+		<value xml:lang="en"><![CDATA[Contents]]></value>
+		<value xml:lang="jp"><![CDATA[Contents]]></value>
+	</item>
+	<item name="ncenterlite_read">
+		<value xml:lang="ko"><![CDATA[읽음 확인]]></value>
+		<value xml:lang="en"><![CDATA[Have read]]></value>
+		<value xml:lang="jp"><![CDATA[Have read]]></value>
+	</item>
+	<item name="ncenterlite_read_y">
+		<value xml:lang="ko"><![CDATA[읽음]]></value>
+		<value xml:lang="en"><![CDATA[Have done]]></value>
+		<value xml:lang="jp"><![CDATA[Have done]]></value>
+	</item>
+	<item name="ncenterlite_read_n">
+		<value xml:lang="ko"><![CDATA[읽지 않음]]></value>
+		<value xml:lang="en"><![CDATA[Have not]]></value>
+		<value xml:lang="jp"><![CDATA[Have not]]></value>
+	</item>
+	<item name="ncenterlite_no_target">
+		<value xml:lang="ko"><![CDATA[대상 없음]]></value>
+		<value xml:lang="en"><![CDATA[no target]]></value>
+		<value xml:lang="jp"><![CDATA[no target]]></value>
+	</item>
+	<item name="ncenterlite_my_list">
+		<value xml:lang="ko"><![CDATA[내 알림 목록]]></value>
+		<value xml:lang="en"><![CDATA[Notification list]]></value>
+		<value xml:lang="jp"><![CDATA[Notification list]]></value>
+	</item>
+	<item name="ncenterlite_my_settings">
+		<value xml:lang="ko"><![CDATA[내 알림 설정]]></value>
+		<value xml:lang="en"><![CDATA[Notification settings]]></value>
+		<value xml:lang="jp"><![CDATA[Notification settings]]></value>
+	</item>
+	<item name="ncenterlite_user_settings">
+		<value xml:lang="ko"><![CDATA[사용자 알림 설정]]></value>
+		<value xml:lang="en"><![CDATA[User notification settings]]></value>
+		<value xml:lang="jp"><![CDATA[User notification settings]]></value>
+	</item>
+	<item name="ncenterlite_userconfig_title">
+		<value xml:lang="ko"><![CDATA[%s님의 알림센터 설정]]></value>
+		<value xml:lang="en"><![CDATA[Notification Center Settings of %s]]></value>
+		<value xml:lang="jp"><![CDATA[Notification Center Settings of %s]]></value>
+	</item>
+	<item name="ncenterlite_userconfig_about">
+		<value xml:lang="ko"><![CDATA[알림센터의 개인의 설정을 저장하도록 합니다.]]></value>
+		<value xml:lang="en"><![CDATA[Personalized settings of notification center can be controlled by you.]]></value>
+		<value xml:lang="jp"><![CDATA[Personalized settings of notification center can be controlled by you.]]></value>
+	</item>
+	<item name="ncenterlite_comment_noti">
+		<value xml:lang="ko"><![CDATA[댓글 알림]]></value>
+		<value xml:lang="en"><![CDATA[Comment notice]]></value>
+		<value xml:lang="jp"><![CDATA[Comment notice]]></value>
+	</item>
+	<item name="ncenterlite_comment_noti_about">
+		<value xml:lang="ko"><![CDATA[내 게시물의 혹은 내 댓글에 댓글이 달릴경우 알림을 받습니다.]]></value>
+		<value xml:lang="en"><![CDATA[Get notice of a comment after someone replies to my documents or comments.]]></value>
+		<value xml:lang="jp"><![CDATA[Get notice of a comment after someone replies to my documents or comments.]]></value>
+	</item>
+	<item name="ncenterlite_mention_noti">
+		<value xml:lang="ko"><![CDATA[멘션 알림]]></value>
+		<value xml:lang="en"><![CDATA[Mention notice]]></value>
+		<value xml:lang="jp"><![CDATA[Mention notice]]></value>
+	</item>
+	<item name="ncenterlite_mention_noti_about">
+		<value xml:lang="ko"><![CDATA[누군가 글, 혹은 댓글을 통해서 나를 맨션 했을 경우 알려줍니다. (맨션 방법 @닉네임 )]]></value>
+		<value xml:lang="en"><![CDATA[Get notice of a mention after someone mention me on documents and/or comments. ( @Nickname to mention )]]></value>
+		<value xml:lang="jp"><![CDATA[Get notice of a mention after someone mention me on documents and/or comments. ( @Nickname to mention )]]></value>
+	</item>
+	<item name="ncenterlite_message_noti">
+		<value xml:lang="ko"><![CDATA[쪽지 알림]]></value>
+		<value xml:lang="en"><![CDATA[Message notice]]></value>
+		<value xml:lang="jp"><![CDATA[Message notice]]></value>
+	</item>
+	<item name="ncenterlite_message_noti_about">
+		<value xml:lang="ko"><![CDATA[누군가에게 받은 쪽지를 알림을 받습니다.]]></value>
+		<value xml:lang="en"><![CDATA[Get notice of a message after someone send the message to me.]]></value>
+		<value xml:lang="jp"><![CDATA[Get notice of a message after someone send the message to me.]]></value>
+	</item>
+	<item name="ncenterlite_activate">
+		<value xml:lang="ko"><![CDATA[사용]]></value>
+		<value xml:lang="en"><![CDATA[Activate]]></value>
+		<value xml:lang="jp"><![CDATA[Activate]]></value>
+	</item>
+	<item name="ncenterlite_inactivate">
+		<value xml:lang="ko"><![CDATA[사용 안함]]></value>
+		<value xml:lang="en"><![CDATA[Inactivate]]></value>
+		<value xml:lang="jp"><![CDATA[Inactivate]]></value>
+	</item>
+	<item name="ncenterlite_userconfig_about_warning">
+		<value xml:lang="ko"><![CDATA[주의! 당신은 관리자 권한으로 다른 사용자의 설정창을 접속하였습니다.]]></value>
+		<value xml:lang="en"><![CDATA[Watch out! You are controlling other user's settings via this page.]]></value>
+		<value xml:lang="jp"><![CDATA[Watch out! You are controlling other user's settings via this page.]]></value>
+	</item>
+	<item name="ncenterlite_article">
+		<value xml:lang="ko"><![CDATA[<strong>%1$s</strong>님이 <strong>"%2$s"</strong>라고 글을 남겼습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%1$s</strong> wrote an article as "%2$s".]]></value>
+		<value xml:lang="jp"><![CDATA[<strong>%1$s</strong> wrote an article as "%2$s".]]></value>
+	</item>
+	<item name="ncenterlite_board">
+		<value xml:lang="ko"><![CDATA[<strong>%1$s</strong>님이 게시판 <strong>"%2$s"</strong>에 <strong>"%3$s"</strong>라고 글을 남겼습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%1$s</strong> wrote an article as "%3$s" on the board %2$s.]]></value>
+		<value xml:lang="jp"><![CDATA[<strong>%1$s</strong> wrote an article as "%3$s" on the board %2$s.]]></value>
+	</item>
 	<item name="ncenterlite_commented">
-		<value xml:lang="ko"><![CDATA[<strong>%s</strong>님이 회원님의 %s에 <strong>"%s" 댓글</strong>을 남겼습니다.]]></value>
-		<value xml:lang="en"><![CDATA[<strong>%s</strong> commented "%s" on your %s.]]></value>
+		<value xml:lang="ko"><![CDATA[<strong>%1$s</strong>님이 회원님의 %2$s에 <strong>"%3$s"</strong>라고 댓글을 남겼습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%1$s</strong> commented as "%3$s" on your %2$s.]]></value>
 		<value xml:lang="jp"><![CDATA[<strong>%s</strong>さんがあなたの%sに<strong>「%s」</strong>とコメントしました。]]></value>
+	</item>
+	<item name="ncenterlite_commented_board">
+		<value xml:lang="ko"><![CDATA[<strong>%1$s</strong>님이 게시판 <strong>"%2$s"</strong>에 <strong>"%3$s"</strong>라고 댓글을 남겼습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%1$s</strong> commented as "%3$s" on the board %2$s.]]></value>
+		<value xml:lang="jp"><![CDATA[<strong>%1$s</strong> commented as "%3$s" on the board %2$s.]]></value>
 	</item>
 	<item name="ncenterlite_mentioned">
 		<value xml:lang="ko"><![CDATA[<strong>%s</strong>님이 <strong>"%s" %s</strong>에서 회원님을 언급하였습니다.]]></value>
@@ -35,9 +155,24 @@
 		<value xml:lang="en"><![CDATA[You have <strong>%d</strong> new <strong>message(s)</strong>.]]></value>
 		<value xml:lang="jp"><![CDATA[<strong>%d</strong>件の読んでない<strong>メッセージ</strong>があります。]]></value>
 	</item>
+	<item name="ncenterlite_message_mention">
+		<value xml:lang="ko"><![CDATA[<strong>%s</strong>님께서 <strong>"%s"</strong>라고 메세지를 보내셨습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%1$s</strong> sent a message as <strong>"%2$s"</strong>.]]></value>
+		<value xml:lang="jp"><![CDATA[<strong>%1$s</strong> sent a message as <strong>"%2$s"</strong>.]]></value>
+	</item>
+	<item name="ncenterlite_test_noti">
+		<value xml:lang="ko"><![CDATA[<strong>%s</strong>님! 스킨 테스트 알림을 완료했습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%s</strong>! Skin test notification has been done.]]></value>
+		<value xml:lang="jp"><![CDATA[<strong>%s</strong>! Skin test notification has been done.]]></value>
+	</item>
+	<item name="ncenterlite_vote">
+		<value xml:lang="ko"><![CDATA[<strong>%s</strong>님이 <strong>"%s"</strong> 글을 추천하였습니다.]]></value>
+		<value xml:lang="en"><![CDATA[<strong>%1$s</strong> marked the article "%2$s" with a recommendation.]]></value>
+		<value xml:lang="jp"><![CDATA[<strong>%1$s</strong> marked the article "%2$s" with a recommendation.]]></value>
+	</item>
 	<item name="ncenterlite_ago">
 		<value xml:lang="ko"><![CDATA[전]]></value>
-		<value xml:lang="en"><![CDATA[Ago]]></value>
+		<value xml:lang="en"><![CDATA[ago]]></value>
 		<value xml:lang="jp"><![CDATA[前]]></value>
 	</item>
 	<item name="ncenterlite_date" type="array">
@@ -74,12 +209,12 @@
 	</item>
 	<item name="ncenterlite_sir">
 		<value xml:lang="ko"><![CDATA[님]]></value>
-		<value xml:lang="en"><![CDATA[]]></value>
+		<value xml:lang="en"><![CDATA[ ]]></value>
 		<value xml:lang="jp"><![CDATA[さん]]></value>
 	</item>
 	<item name="ncenterlite_message">
 		<value xml:lang="ko"><![CDATA[<strong class="num">%s</strong>개의 알림이 있습니다.]]></value>
-		<value xml:lang="en"><![CDATA[you have <strong class="num">%s</strong> notification.]]></value>
+		<value xml:lang="en"><![CDATA[You have <strong class="num">%s</strong> notification.]]></value>
 		<value xml:lang="jp"><![CDATA[<strong class="num">%s</strong>件のお知らせがあります。]]></value>
 	</item>
 	<item name="ncenterlite_messages">
@@ -96,5 +231,30 @@
 		<value xml:lang="ko"><![CDATA[더보기]]></value>
 		<value xml:lang="en"><![CDATA[More]]></value>
 		<value xml:lang="jp"><![CDATA[もっと見る]]></value>
+	</item>
+	<item name="ncenterlite_stop_login_required">
+		<value xml:lang="ko"><![CDATA[알림센터 설정을 하시려면 로그인 해주세요.]]></value>
+		<value xml:lang="en"><![CDATA[Sign in to control your own notification settings.]]></value>
+		<value xml:lang="jp"><![CDATA[Sign in to control your own notification settings.]]></value>
+	</item>
+	<item name="ncenterlite_stop_no_permission_other_user">
+		<value xml:lang="ko"><![CDATA[다른 회원의 설정을 볼 권한이 없습니다.]]></value>
+		<value xml:lang="en"><![CDATA[You don't have the authority to read settings of other members.]]></value>
+		<value xml:lang="jp"><![CDATA[You don't have the authority to read settings of other members.]]></value>
+	</item>
+	<item name="ncenterlite_stop_no_permission_other_user_settings">
+		<value xml:lang="ko"><![CDATA[다른 회원의 설정을 변경할 권한이 없습니다.]]></value>
+		<value xml:lang="en"><![CDATA[You don't have the authority to control settings of other members.]]></value>
+		<value xml:lang="jp"><![CDATA[You don't have the authority to control settings of other members.]]></value>
+	</item>
+	<item name="ncenterlite_message_delete_notification_before">
+		<value xml:lang="ko"><![CDATA[%s 이전 알림 정보를 삭제했습니다.]]></value>
+		<value xml:lang="en"><![CDATA[Notifications before %s are deleted.]]></value>
+		<value xml:lang="jp"><![CDATA[Notifications before %s are deleted.]]></value>
+	</item>
+	<item name="ncenterlite_message_delete_notification_all">
+		<value xml:lang="ko"><![CDATA[모든 알림을 삭제했습니다.]]></value>
+		<value xml:lang="en"><![CDATA[Every notification is deleted.]]></value>
+		<value xml:lang="jp"><![CDATA[Every notification is deleted.]]></value>
 	</item>
 </lang>

--- a/lang/lang.xml
+++ b/lang/lang.xml
@@ -248,7 +248,7 @@
 		<value xml:lang="jp"><![CDATA[You don't have the authority to control settings of other members.]]></value>
 	</item>
 	<item name="ncenterlite_message_delete_notification_before">
-		<value xml:lang="ko"><![CDATA[%s 이전 알림 정보를 삭제했습니다.]]></value>
+		<value xml:lang="ko"><![CDATA[%s까지 알림 정보를 삭제했습니다.]]></value>
 		<value xml:lang="en"><![CDATA[Notifications before %s are deleted.]]></value>
 		<value xml:lang="jp"><![CDATA[Notifications before %s are deleted.]]></value>
 	</item>

--- a/lang/lang.xml
+++ b/lang/lang.xml
@@ -42,13 +42,13 @@
 	</item>
 	<item name="ncenterlite_read_y">
 		<value xml:lang="ko"><![CDATA[읽음]]></value>
-		<value xml:lang="en"><![CDATA[Have done]]></value>
-		<value xml:lang="jp"><![CDATA[Have done]]></value>
+		<value xml:lang="en"><![CDATA[Have read]]></value>
+		<value xml:lang="jp"><![CDATA[Have read]]></value>
 	</item>
 	<item name="ncenterlite_read_n">
 		<value xml:lang="ko"><![CDATA[읽지 않음]]></value>
-		<value xml:lang="en"><![CDATA[Have not]]></value>
-		<value xml:lang="jp"><![CDATA[Have not]]></value>
+		<value xml:lang="en"><![CDATA[Not read]]></value>
+		<value xml:lang="jp"><![CDATA[Not read]]></value>
 	</item>
 	<item name="ncenterlite_no_target">
 		<value xml:lang="ko"><![CDATA[대상 없음]]></value>

--- a/m.skins/default/NotifyList.html
+++ b/m.skins/default/NotifyList.html
@@ -15,8 +15,8 @@
 				<div class="history-text">
 					<span class="history-ip"><strong><a href="{$val->target_url}">{$val->text}</a></strong></span>
 					<span class="history-auth">({zdate($val->regdate,"Y-m-d H:i:s")})</span>
-					<span class="history-auth" cond="$val->readed=='Y'">(읽음)</span>
-					<span class="history-auth" cond="$val->readed=='N'">(읽지 않음)</span>
+					<span class="history-auth" cond="$val->readed=='Y'">({$lang->ncenterlite_read_y})</span>
+					<span class="history-auth" cond="$val->readed=='N'">({$lang->ncenterlite_read_n})</span>
 				</div>
 			</div>
 		</li>

--- a/m.skins/default/NotifyList.html
+++ b/m.skins/default/NotifyList.html
@@ -1,6 +1,6 @@
 <load target="notify.css" />
 <div class="sosifam">
-	<h2 class="sosi-title">내 알림 목록</h2>
+	<h2 class="sosi-title">{$lang->ncenterlite_my_list}</h2>
 	<ul class="history-list cfix">
 		<li class="history-item cfix" loop="$ncenterlite_list => $no, $val">
 		{@

--- a/m.skins/default/notify.css
+++ b/m.skins/default/notify.css
@@ -2,8 +2,8 @@
 
 .sosi-title {
 	position: relative;
-	font-size: 15px;
-	font-style: italic;
+	font-size: 16px;
+	font-style: bold;
 	display: block;
 	margin: 14px 0 14px 14px;
 	width: auto;

--- a/m.skins/default/userconfig.html
+++ b/m.skins/default/userconfig.html
@@ -1,48 +1,58 @@
 <load target="../../../member/skins/default/css/member.css" />
 <div class="xm">
 
+<div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/ncenterlite/m.skins/default/userconfig/1'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
+	<p>{$XE_VALIDATOR_MESSAGE}</p>
+</div>
+
+
 <form ruleset="insertConfig" action="./" method="post" class="form-horizontal" id="fo_ncenterlite">
 	<input type="hidden" name="module" value="ncenterlite" />
 	<input type="hidden" name="act" value="procNcenterliteUserConfig" />
+	<input type="hidden" name="xe_validator_id" value="modules/ncenterlite/m.skins/default/userconfig/1" />
+	<input type="hidden" name="member_srl" value="{$member_srl}">
 	<section class="section">
-		<h1><block cond="$member_info">{$member_info->nick_name}</block>
-			<block cond="!$member_info">{$logged_info->nick_name}</block>님의 알림센터 설정</h1>
+		<h1><block cond="$member_info">{@$user_str = $member_info->nick_name}</block>
+			<block cond="!$member_info">{@$user_str = $logged_info->nick_name}</block>
+			{@$title_str = Context::getLang('ncenterlite_userconfig_title')}
+			{sprintf($title_str, $user_str)}
+		</h1>
 
-		<p>알림센터의 개인의 설정을 저장하도록 합니다.<block cond="$member_info">(주의! 당신은 관리자 권한으로 다른유저의 설정창을 접속하였습니다.)</block></p>
+		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_info">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
 		<div class="control-group">
-			<label class="control-label">댓글 알림</label>
+			<label class="control-label">{$lang->ncenterlite_comment_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="comment_notify" value="Y" checked="checked"|cond="$user_config->comment_notify == 'Y'" /> 사용
+					<input type="radio" name="comment_notify" value="Y" checked="checked"|cond="$user_config->comment_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="comment_notify" value="N" checked="checked"|cond="$user_config->comment_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="comment_notify" value="N" checked="checked"|cond="$user_config->comment_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">내 게시물의 혹은 내 댓글에 댓글이 달릴경우 알림을 받습니다.</p>
+				<p class="help-block">{$lang->ncenterlite_comment_noti_about}</p>
 			</div>
 		</div>
 		<div class="control-group">
-			<label class="control-label">맨션 알림</label>
+			<label class="control-label">{$lang->ncenterlite_mention_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="mention_notify" value="Y" checked="checked"|cond="$user_config->mention_notify == 'Y'" /> 사용
+					<input type="radio" name="mention_notify" value="Y" checked="checked"|cond="$user_config->mention_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="mention_notify" value="N" checked="checked"|cond="$user_config->mention_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="mention_notify" value="N" checked="checked"|cond="$user_config->mention_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">누군가 글, 혹은 댓글을 통해서 나를 맨션 했을 경우 알려줍니다. (맨션 방법 @닉네임 )</p>
+				<p class="help-block">{$lang->ncenterlite_mention_noti_about}</p>
 			</div>
 		</div>
 		<div class="control-group">
-			<label class="control-label">쪽지 알림</label>
+			<label class="control-label">{$lang->ncenterlite_message_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="message_notify" value="Y" checked="checked"|cond="$user_config->message_notify == 'Y'" /> 사용
+					<input type="radio" name="message_notify" value="Y" checked="checked"|cond="$user_config->message_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="message_notify" value="N" checked="checked"|cond="$user_config->message_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="message_notify" value="N" checked="checked"|cond="$user_config->message_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">누군가에게 받은 쪽지를 알림을 받습니다.</p>
+				<p class="help-block">{$lang->ncenterlite_message_noti_about}</p>
 			</div>
 		</div>
 

--- a/m.skins/default/userconfig.html
+++ b/m.skins/default/userconfig.html
@@ -18,7 +18,7 @@
 			{sprintf($title_str, $user_str)}
 		</h1>
 
-		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_info">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
+		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_srl && $member_srl != $logged_info->member_srl">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
 		<div class="control-group">
 			<label class="control-label">{$lang->ncenterlite_comment_noti}</label>
 			<div class="controls">

--- a/ncenterlite.admin.controller.php
+++ b/ncenterlite.admin.controller.php
@@ -114,11 +114,13 @@ class ncenterliteAdminController extends ncenterlite
 
 		if($old_date)
 		{
-			$this->setMessage('1달 이전 정보를 삭제하였습니다.');
+			$message = Context::getLang('ncenterlite_message_delete_notification_before');
+			$message = sprintf($message, getTimeGap($old_date, $format = 'Y/m/d') );
+			$this->setMessage($message);
 		}
 		else
 		{
-			$this->setMessage('모든 정보를 삭제하였습니다.');
+			$this->setMessage('ncenterlite_message_delete_notification_all');
 		}
 		
 		if(!in_array(Context::getRequestMethod(),array('XMLRPC','JSON')))

--- a/ncenterlite.admin.controller.php
+++ b/ncenterlite.admin.controller.php
@@ -114,8 +114,9 @@ class ncenterliteAdminController extends ncenterlite
 
 		if($old_date)
 		{
+			$oNcenterliteModel = getModel('ncenterlite');
 			$message = Context::getLang('ncenterlite_message_delete_notification_before');
-			$message = sprintf($message, getTimeGap($old_date, $format = 'Y/m/d') );
+			$message = sprintf($message, $oNcenterliteModel->getAgo($old_date) );
 			$this->setMessage($message);
 		}
 		else

--- a/ncenterlite.admin.model.php
+++ b/ncenterlite.admin.model.php
@@ -41,8 +41,8 @@ class ncenterliteAdminModel extends ncenterlite
 					//$str = sprintf('<strong>%s</strong>님이 회원님의 %s에 <strong>"%s" 댓글</strong>을 남겼습니다.', $target_member, $type, $v->target_summary);
 				break;
 				case 'A':
-					$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>게시판에 <strong>"%s"</strong>댓글을 남겼습니다. ', $target_member, $v->target_browser, $v->target_summary);
-					//$str = sprintf('<strong>%s</strong>님이 회원님의 %s에 <strong>"%s" 댓글</strong>을 남겼습니다.', $target_member, $type, $v->target_summary);
+					$str = sprintf($lang->ncenterlite_commented_board, $target_member, $v->target_browser, $v->target_summary);
+					//$str = sprintf('<strong>%1$s</strong>님이 게시판 <strong>"%2$s"</strong>에 <strong>"%3$s"</strong>라고 댓글을 남겼습니다.', $target_member, $type, $v->target_summary);
 				break;
 				case 'M':
 					$str = sprintf($lang->ncenterlite_mentioned, $target_member,  $v->target_summary, $type);
@@ -52,7 +52,8 @@ class ncenterliteAdminModel extends ncenterlite
 				case 'E':
 					if(version_compare(__XE_VERSION__, '1.7.4', '>='))
 					{
-						$str = sprintf('<strong>%s</strong>님께서 <strong>%s</strong> 메세지를 보내셨습니다.',$target_member, $v->target_summary);
+						$str = sprintf($lang->ncenterlite_message_mention, $target_member, $v->target_summary);
+						//<strong>%s</strong>님께서 <strong>"%s"</strong>라고 메세지를 보내셨습니다.
 					}
 					else
 					{
@@ -60,23 +61,24 @@ class ncenterliteAdminModel extends ncenterlite
 					}
 				break;
 				case 'T':
-					$str = sprintf('<strong>%s</strong>님! 스킨 테스트 알림을 완료했습니다.', $target_member);
+					$str = sprintf($lang->ncenterlite_test_noti, $target_member);
 				break;
 				case 'P':
-					$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>게시판에 <strong>%s</strong>글을 남겼습니다.', $target_member, $v->target_browser, $v->target_summary);
+					$str = sprintf($lang->ncenterlite_board, $target_member, $v->target_browser, $v->target_summary);
+					//<strong>%1$s</strong>님이 게시판 <strong>"%2$s"</strong>에 <strong>"%3$s"</strong>라고 글을 남겼습니다.
 				break;
 				case 'S':
 					if($v->target_browser)
 					{
-						$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>게시판에 <strong>"%s"</strong>글을 남겼습니다.', $target_member, $v->target_browser, $v->target_summary);
+						$str = sprintf($lang->ncenterlite_board, $target_member, $v->target_browser, $v->target_summary);
 					}
 					else
 					{
-						$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>글을 남겼습니다.', $target_member, $v->target_summary);
+						$str = sprintf($lang->ncenterlite_article, $target_member, $v->target_summary);
 					}
 				break;
 				case 'V':
-					$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>글을 추천하였습니다.', $target_member, $v->target_summary);
+					$str = sprintf($lang->ncenterlite_vote, $target_member, $v->target_summary);
 				break;
 			}
 

--- a/ncenterlite.controller.php
+++ b/ncenterlite.controller.php
@@ -13,7 +13,7 @@ class ncenterliteController extends ncenterlite
 			$member_srl = $logged_info->member_srl;
 		}
 
-		if($logged_info->member_srl != $member_srl && $logged_info->is_admin != 'Y') return new Object(-1, '다른회원의 설정을 변경할 권한이 없습니다.');
+		if($logged_info->member_srl != $member_srl && $logged_info->is_admin != 'Y') return new Object(-1, 'ncenterlite_stop_no_permission_other_user_settings');
 
 		$output = $oNcenterliteModel->getMemberConfig($member_srl);
 
@@ -715,7 +715,7 @@ class ncenterliteController extends ncenterlite
 			}
 		}
 
-		Context::addHtmlFooter('<script type="text/javascript">');
+		Context::addHtmlFooter('<script>');
 		if($config->message_notify != 'N') Context::addHtmlFooter('window.xeNotifyMessage = function() {};');
 		Context::addHtmlFooter('(function(){setTimeout(function(){var s = jQuery(document).scrollTop();jQuery(document).scrollTop(s-30);}, 700);})();</script>');
 
@@ -736,13 +736,14 @@ class ncenterliteController extends ncenterlite
 			$target_srl = Context::get('target_srl');
 
 			$oMemberController = getController('member');
-			$oMemberController->addMemberMenu('dispNcenterliteNotifyList', '내 알림 목록');
-			$oMemberController->addMemberMenu('dispNcenterliteUserConfig', '내 알림 설정');
+			$oMemberController->addMemberMenu('dispNcenterliteNotifyList', 'ncenterlite_my_list');
+			$oMemberController->addMemberMenu('dispNcenterliteUserConfig', 'ncenterlite_my_settings');
 
 			if($logged_info->is_admin== 'Y')
 			{
 				$url = getUrl('','act','dispNcenterliteUserConfig','member_srl',$target_srl);
-				$oMemberController->addMemberPopupMenu($url, '유저 알림 설정', '');
+				$str = Context::getLang('ncenterlite_user_settings');
+				$oMemberController->addMemberPopupMenu($url, $str, '');
 			}
 		}
 
@@ -864,7 +865,7 @@ class ncenterliteController extends ncenterlite
 		if(!$output->toBool()) return $output;
 
 		$url = str_replace('&amp;', '&', $url);
-		header('location: ' . $url);
+		header('Location: ' . $url, TRUE, 302);
 		Context::close();
 		exit;
 	}

--- a/ncenterlite.mobile.php
+++ b/ncenterlite.mobile.php
@@ -1,6 +1,6 @@
 <?php
 
-class ncenterliteMobile extends ncenterlite
+class ncenterliteMobile extends ncenterliteView
 {
 	function init()
 	{
@@ -27,49 +27,12 @@ class ncenterliteMobile extends ncenterlite
 
 	function dispNcenterliteNotifyList()
 	{
-		$oNcenterliteModel = getModel('ncenterlite');
-
-		$output = $oNcenterliteModel->getMyNotifyList();
-
-		Context::set('total_count', $output->page_navigation->total_count);
-		Context::set('total_page', $output->page_navigation->total_page);
-		Context::set('page', $output->page);
-		Context::set('ncenterlite_list', $output->data);
-		Context::set('page_navigation', $output->page_navigation);
-
-		$this->setTemplateFile('NotifyList');
+		parent::dispNcenterliteNotifyList();
 	}
 
 	function dispNcenterliteUserConfig()
 	{
-		$oMemberModel = getModel('member');
-
-		$logged_info = Context::get('logged_info');
-		if(!$logged_info) return new Object(-1, 'ncenterlite_stop_login_required');
-
-		if($logged_info->is_admin == 'Y')
-		{
-			$member_srl = Context::get('member_srl');
-			$member_info = $oMemberModel->getMemberInfoByMemberSrl($member_srl);
-		}
-
-		if($logged_info->is_admin != 'Y' && Context::get('member_srl'))
-		{
-			return new Object(-1, 'ncenterlite_stop_no_permission_other_user');
-		}
-
-		$oNcenterliteModel = getModel('ncenterlite');
-
-		if(!$member_srl)
-		{
-			$member_srl = $logged_info->member_srl;
-		}
-
-		$output = $oNcenterliteModel->getMemberConfig($member_srl);
-
-		Context::set('member_info', $member_info);
-		Context::set('user_config', $output->data);
-		$this->setTemplateFile('userconfig');
+		parent::dispNcenterliteUserConfig();
 	}
 
 }

--- a/ncenterlite.mobile.php
+++ b/ncenterlite.mobile.php
@@ -45,7 +45,7 @@ class ncenterliteMobile extends ncenterlite
 		$oMemberModel = getModel('member');
 
 		$logged_info = Context::get('logged_info');
-		if(!$logged_info) return new Object(-1, '로그인 사용자만 접근할 수 있습니다.');
+		if(!$logged_info) return new Object(-1, 'ncenterlite_stop_login_required');
 
 		if($logged_info->is_admin == 'Y')
 		{
@@ -55,7 +55,7 @@ class ncenterliteMobile extends ncenterlite
 
 		if($logged_info->is_admin != 'Y' && Context::get('member_srl'))
 		{
-			return new Object(-1, '다른회원의 설정을 볼 권한이 없습니다.');
+			return new Object(-1, 'ncenterlite_stop_no_permission_other_user');
 		}
 
 		$oNcenterliteModel = getModel('ncenterlite');

--- a/ncenterlite.model.php
+++ b/ncenterlite.model.php
@@ -152,8 +152,8 @@ class ncenterliteModel extends ncenterlite
 					//$str = sprintf('<strong>%s</strong>님이 회원님의 %s에 <strong>"%s" 댓글</strong>을 남겼습니다.', $target_member, $type, $v->target_summary);
 				break;
 				case 'A':
-					$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>게시판에 <strong>"%s"</strong>댓글을 남겼습니다. ', $target_member, $v->target_browser, $v->target_summary);
-					//$str = sprintf('<strong>%s</strong>님이 회원님의 %s에 <strong>"%s" 댓글</strong>을 남겼습니다.', $target_member, $type, $v->target_summary);
+					$str = sprintf($lang->ncenterlite_commented_board, $target_member, $v->target_browser, $v->target_summary);
+					//$str = sprintf('<strong>%1$s</strong>님이 게시판 <strong>"%2$s"</strong>에 <strong>"%3$s"</strong>라고 댓글을 남겼습니다.', $target_member, $type, $v->target_summary);
 				break;
 				case 'M':
 					$str = sprintf($lang->ncenterlite_mentioned, $target_member,  $v->target_summary, $type);
@@ -163,7 +163,7 @@ class ncenterliteModel extends ncenterlite
 				case 'E':
 					if(version_compare(__XE_VERSION__, '1.7.4', '>='))
 					{
-						$str = sprintf('<strong>%s</strong>님께서 <strong>%s</strong> 메세지를 보내셨습니다.',$target_member, $v->target_summary);
+						$str = sprintf($lang->ncenterlite_message_mention,$target_member, $v->target_summary);
 					}
 					else
 					{
@@ -171,23 +171,23 @@ class ncenterliteModel extends ncenterlite
 					}
 				break;
 				case 'T':
-					$str = sprintf('<strong>%s</strong>님! 스킨 테스트 알림을 완료했습니다.', $target_member);
+					$str = sprintf($lang->ncenterlite_test_noti, $target_member);
 				break;
 				case 'P':
-					$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>게시판에 <strong>%s</strong>글을 남겼습니다.', $target_member, $v->target_browser, $v->target_summary);
+					$str = sprintf($lang->ncenterlite_board, $target_member, $v->target_browser, $v->target_summary);
 				break;
 				case 'S':
 					if($v->target_browser)
 					{
-						$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>게시판에 <strong>"%s"</strong>글을 남겼습니다.', $target_member, $v->target_browser, $v->target_summary);
+						$str = sprintf($lang->ncenterlite_board, $target_member, $v->target_browser, $v->target_summary);
 					}
 					else
 					{
-						$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>글을 남겼습니다.', $target_member, $v->target_summary);
+						$str = sprintf($lang->ncenterlite_article, $target_member, $v->target_summary);
 					}
 				break;
 				case 'V':
-					$str = sprintf('<strong>%s</strong>님이 <strong>"%s"</strong>글을 추천하였습니다.', $target_member, $v->target_summary);
+					$str = sprintf($lang->ncenterlite_vote, $target_member, $v->target_summary);
 				break;
 			}
 

--- a/ncenterlite.view.php
+++ b/ncenterlite.view.php
@@ -44,7 +44,7 @@ class ncenterliteView extends ncenterlite
 		$oMemberModel = getModel('member');
 		$member_srl = Context::get('member_srl');
 		$logged_info = Context::get('logged_info');
-		if(!$logged_info) return new Object(-1, '로그인 사용자만 접근할 수 있습니다.');
+		if(!$logged_info) return new Object(-1, 'ncenterlite_stop_login_required');
 
 		if($logged_info->is_admin == 'Y')
 		{
@@ -54,7 +54,7 @@ class ncenterliteView extends ncenterlite
 		{
 			if($member_srl != $logged_info->member_srl)
 			{
-				return new Object(-1, '다른회원의 설정을 볼 권한이 없습니다.');
+				return new Object(-1, 'ncenterlite_stop_no_permission_other_user');
 			}
 		}
 		$oNcenterliteModel = getModel('ncenterlite');

--- a/skins/default/NotifyList.html
+++ b/skins/default/NotifyList.html
@@ -1,13 +1,12 @@
-<load target="css/notify.css" />
 <include target="../../../member/skins/default/common_header.html" />
 <table class="table table-striped table-hover" style="margin-top:20px;">
 	<thead class="bg_f_f9">
 		<tr>
-			<th scope="col" class="nowr" style="width:100px;">보낸사람</th>
-			<th scope="col" style="width:100px;">받은사람</th>
-			<th scope="col" style="width:500px;">내용</th>
-			<th scope="col" style="width:50px;">읽음여부</th>
-			<th scope="col" style="width:100px;">{$lang->date}</th>
+			<th scope="col" class="nowr">{$lang->ncenterlite_sender}</th>
+			<th scope="col">{$lang->ncenterlite_addressee}</th>
+			<th scope="col">{$lang->ncenterlite_noti_contents}</th>
+			<th scope="col">{$lang->ncenterlite_read}</th>
+			<th scope="col">{$lang->date}</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -18,9 +17,12 @@
 		}
 		<tr>
 			<td>{$val->target_nick_name}</td>
-			<td cond="$member_info->member_srl">{$member_info->nick_name}</td> <td cond="!$member_info->member_srl">타겟없음</td>
+			<td cond="$member_info->member_srl">{$member_info->nick_name}</td> <td cond="!$member_info->member_srl">{$lang->ncenterlite_no_target}</td>
 			<td><a href="{$val->target_url}">{$val->text}</a></td>
-			<td>{$val->readed}</td>
+			<td>
+				<span class="history-auth" cond="$val->readed=='Y'">{$lang->ncenterlite_read_y}</span>
+				<span class="history-auth" cond="$val->readed=='N'">{$lang->ncenterlite_read_n}</span>
+			</td>
 			<td>
 				{zdate($val->regdate,"Y-m-d")}
 				</br>
@@ -40,3 +42,5 @@
 		<li><a href="{getUrl('page',$page_navigation->last_page)}" class="direction">{$lang->last_page} &raquo;</a></li>
 	</ul>
 </div>
+
+<include target="../../../member/skins/default/common_footer.html" />

--- a/skins/default/skin.xml
+++ b/skins/default/skin.xml
@@ -1,32 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skin version="0.2">
 	<title xml:lang="ko">XE 알림센터 Lite 기본스킨</title>
+	<title xml:lang="en">XE Notification Center Lite Default Skin</title>
 	<version>1.1.1</version>
 	<date>2013-03-21</date>
 
 	<author email_address="info@xemagazine.com" link="http://xmz.kr/">
 		<name xml:lang="ko">XE Public</name>
+		<name xml:lang="en">XE Public</name>
 	</author>
 
 	<colorset>
 		<color name="black">
 			<title xml:lang="ko">검은색</title>
+			<title xml:lang="en">Black</title>
 		</color>
 		<color name="gray">
 			<title xml:lang="ko">회색</title>
+			<title xml:lang="en">Gray</title>
 		</color>
 		<color name="white">
 			<title xml:lang="ko">흰색</title>
+			<title xml:lang="en">White</title>
 		</color>
 
 		<color name="blacknoprofile">
 			<title xml:lang="ko">검은색(no profile)</title>
+			<title xml:lang="en">Black (no profile)</title>
 		</color>
 		<color name="graynoprofile">
 			<title xml:lang="ko">회색(no profile)</title>
+			<title xml:lang="en">Gray (no profile)</title>
 		</color>
 		<color name="whitenoprofile">
 			<title xml:lang="ko">흰색(no profile)</title>
+			<title xml:lang="en">White (no profile)</title>
 		</color>
 	</colorset>
 </skin>

--- a/skins/default/userconfig.html
+++ b/skins/default/userconfig.html
@@ -19,7 +19,7 @@
 			{sprintf($title_str, $user_str)}
 		</h1>
 
-		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_info">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
+		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_srl && $member_srl != $logged_info->member_srl">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
 		<div class="control-group">
 			<label class="control-label">{$lang->ncenterlite_comment_noti}</label>
 			<div class="controls">

--- a/skins/default/userconfig.html
+++ b/skins/default/userconfig.html
@@ -1,4 +1,5 @@
 <load target="../../../member/skins/default/css/member.css" />
+<include target="../../../member/skins/default/common_header.html" />
 <div class="xm">
 
 <div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/ncenterlite/skins/default/userconfig/1'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
@@ -12,44 +13,47 @@
 	<input type="hidden" name="xe_validator_id" value="modules/ncenterlite/skins/default/userconfig/1" />
 	<input type="hidden" name="member_srl" value="{$member_srl}">
 	<section class="section">
-		<h1><block cond="$member_info">{$member_info->nick_name}</block>
-			<block cond="!$member_info">{$logged_info->nick_name}</block>님의 알림센터 설정</h1>
+		<h1><block cond="$member_info">{@$user_str = $member_info->nick_name}</block>
+			<block cond="!$member_info">{@$user_str = $logged_info->nick_name}</block>
+			{@$title_str = Context::getLang('ncenterlite_userconfig_title')}
+			{sprintf($title_str, $user_str)}
+		</h1>
 
-		<p>알림센터의 개인의 설정을 저장하도록 합니다.<block cond="$member_info">(주의! 당신은 관리자 권한으로 다른유저의 설정창을 접속하였습니다.)</block></p>
+		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_info">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
 		<div class="control-group">
-			<label class="control-label">댓글 알림</label>
+			<label class="control-label">{$lang->ncenterlite_comment_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="comment_notify" value="Y" checked="checked"|cond="$user_config->comment_notify == 'Y'" /> 사용
+					<input type="radio" name="comment_notify" value="Y" checked="checked"|cond="$user_config->comment_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="comment_notify" value="N" checked="checked"|cond="$user_config->comment_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="comment_notify" value="N" checked="checked"|cond="$user_config->comment_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">내 게시물의 혹은 내 댓글에 댓글이 달릴경우 알림을 받습니다.</p>
+				<p class="help-block">{$lang->ncenterlite_comment_noti_about}</p>
 			</div>
 		</div>
 		<div class="control-group">
-			<label class="control-label">맨션 알림</label>
+			<label class="control-label">{$lang->ncenterlite_mention_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="mention_notify" value="Y" checked="checked"|cond="$user_config->mention_notify == 'Y'" /> 사용
+					<input type="radio" name="mention_notify" value="Y" checked="checked"|cond="$user_config->mention_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="mention_notify" value="N" checked="checked"|cond="$user_config->mention_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="mention_notify" value="N" checked="checked"|cond="$user_config->mention_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">누군가 글, 혹은 댓글을 통해서 나를 맨션 했을 경우 알려줍니다. (맨션 방법 @닉네임 )</p>
+				<p class="help-block">{$lang->ncenterlite_mention_noti_about}</p>
 			</div>
 		</div>
 		<div class="control-group">
-			<label class="control-label">쪽지 알림</label>
+			<label class="control-label">{$lang->ncenterlite_message_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="message_notify" value="Y" checked="checked"|cond="$user_config->message_notify == 'Y'" /> 사용
+					<input type="radio" name="message_notify" value="Y" checked="checked"|cond="$user_config->message_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="message_notify" value="N" checked="checked"|cond="$user_config->message_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="message_notify" value="N" checked="checked"|cond="$user_config->message_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">누군가에게 받은 쪽지를 알림을 받습니다.</p>
+				<p class="help-block">{$lang->ncenterlite_message_noti_about}</p>
 			</div>
 		</div>
 
@@ -61,3 +65,4 @@
 	</div>
 </form>
 </div>
+<include target="../../../member/skins/default/common_footer.html" />

--- a/skins/default_bottom/NotifyList.html
+++ b/skins/default_bottom/NotifyList.html
@@ -1,13 +1,12 @@
-<load target="css/notify.css" />
 <include target="../../../member/skins/default/common_header.html" />
 <table class="table table-striped table-hover" style="margin-top:20px;">
 	<thead class="bg_f_f9">
 		<tr>
-			<th scope="col" class="nowr" style="width:100px;">보낸사람</th>
-			<th scope="col" style="width:100px;">받은사람</th>
-			<th scope="col" style="width:500px;">내용</th>
-			<th scope="col" style="width:50px;">읽음여부</th>
-			<th scope="col" style="width:100px;">{$lang->date}</th>
+			<th scope="col" class="nowr">{$lang->ncenterlite_sender}</th>
+			<th scope="col">{$lang->ncenterlite_addressee}</th>
+			<th scope="col">{$lang->ncenterlite_noti_contents}</th>
+			<th scope="col">{$lang->ncenterlite_read}</th>
+			<th scope="col">{$lang->date}</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -18,9 +17,12 @@
 		}
 		<tr>
 			<td>{$val->target_nick_name}</td>
-			<td cond="$member_info->member_srl">{$member_info->nick_name}</td> <td cond="!$member_info->member_srl">타겟없음</td>
+			<td cond="$member_info->member_srl">{$member_info->nick_name}</td> <td cond="!$member_info->member_srl">{$lang->ncenterlite_no_target}</td>
 			<td><a href="{$val->target_url}">{$val->text}</a></td>
-			<td>{$val->readed}</td>
+			<td>
+				<span class="history-auth" cond="$val->readed=='Y'">{$lang->ncenterlite_read_y}</span>
+				<span class="history-auth" cond="$val->readed=='N'">{$lang->ncenterlite_read_n}</span>
+			</td>
 			<td>
 				{zdate($val->regdate,"Y-m-d")}
 				</br>
@@ -40,3 +42,5 @@
 		<li><a href="{getUrl('page',$page_navigation->last_page)}" class="direction">{$lang->last_page} &raquo;</a></li>
 	</ul>
 </div>
+
+<include target="../../../member/skins/default/common_footer.html" />

--- a/skins/default_bottom/skin.xml
+++ b/skins/default_bottom/skin.xml
@@ -1,32 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <skin version="0.2">
 	<title xml:lang="ko">XE 알림센터 Lite 기본스킨 - 우측 하단</title>
+	<title xml:lang="en">XE Notification Center Lite Default Skin - Right bottom</title>
 	<version>1.2.0</version>
 	<date>2013-05-10</date>
 
 	<author email_address="info@xemagazine.com" link="http://xmz.kr/">
 		<name xml:lang="ko">XE Public</name>
+		<name xml:lang="en">XE Public</name>
 	</author>
 
 	<colorset>
 		<color name="black">
 			<title xml:lang="ko">검은색</title>
+			<title xml:lang="en">Black</title>
 		</color>
 		<color name="gray">
 			<title xml:lang="ko">회색</title>
+			<title xml:lang="en">Gray</title>
 		</color>
 		<color name="white">
 			<title xml:lang="ko">흰색</title>
+			<title xml:lang="en">White</title>
 		</color>
 
 		<color name="blacknoprofile">
 			<title xml:lang="ko">검은색(no profile)</title>
+			<title xml:lang="en">Black (no profile)</title>
 		</color>
 		<color name="graynoprofile">
 			<title xml:lang="ko">회색(no profile)</title>
+			<title xml:lang="en">Gray (no profile)</title>
 		</color>
 		<color name="whitenoprofile">
 			<title xml:lang="ko">흰색(no profile)</title>
+			<title xml:lang="en">White (no profile)</title>
 		</color>
 	</colorset>
 </skin>

--- a/skins/default_bottom/userconfig.html
+++ b/skins/default_bottom/userconfig.html
@@ -19,7 +19,7 @@
 			{sprintf($title_str, $user_str)}
 		</h1>
 
-		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_info">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
+		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_srl && $member_srl != $logged_info->member_srl">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
 		<div class="control-group">
 			<label class="control-label">{$lang->ncenterlite_comment_noti}</label>
 			<div class="controls">

--- a/skins/default_bottom/userconfig.html
+++ b/skins/default_bottom/userconfig.html
@@ -1,4 +1,5 @@
 <load target="../../../member/skins/default/css/member.css" />
+<include target="../../../member/skins/default/common_header.html" />
 <div class="xm">
 
 <div cond="$XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID == 'modules/ncenterlite/skins/default_bottom/userconfig/1'" class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
@@ -12,44 +13,47 @@
 	<input type="hidden" name="xe_validator_id" value="modules/ncenterlite/skins/default_bottom/userconfig/1" />
 	<input type="hidden" name="member_srl" value="{$member_srl}">
 	<section class="section">
-		<h1><block cond="$member_info">{$member_info->nick_name}</block>
-			<block cond="!$member_info">{$logged_info->nick_name}</block>님의 알림센터 설정</h1>
+		<h1><block cond="$member_info">{@$user_str = $member_info->nick_name}</block>
+			<block cond="!$member_info">{@$user_str = $logged_info->nick_name}</block>
+			{@$title_str = Context::getLang('ncenterlite_userconfig_title')}
+			{sprintf($title_str, $user_str)}
+		</h1>
 
-		<p>알림센터의 개인의 설정을 저장하도록 합니다.<block cond="$member_info">(주의! 당신은 관리자 권한으로 다른유저의 설정창을 접속하였습니다.)</block></p>
+		<p>{$lang->ncenterlite_userconfig_about} <strong style="color:#ff0000" cond="$member_info">({$lang->ncenterlite_userconfig_about_warning})</strong></p>
 		<div class="control-group">
-			<label class="control-label">댓글 알림</label>
+			<label class="control-label">{$lang->ncenterlite_comment_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="comment_notify" value="Y" checked="checked"|cond="$user_config->comment_notify == 'Y'" /> 사용
+					<input type="radio" name="comment_notify" value="Y" checked="checked"|cond="$user_config->comment_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="comment_notify" value="N" checked="checked"|cond="$user_config->comment_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="comment_notify" value="N" checked="checked"|cond="$user_config->comment_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">내 게시물의 혹은 내 댓글에 댓글이 달릴경우 알림을 받습니다.</p>
+				<p class="help-block">{$lang->ncenterlite_comment_noti_about}</p>
 			</div>
 		</div>
 		<div class="control-group">
-			<label class="control-label">맨션 알림</label>
+			<label class="control-label">{$lang->ncenterlite_mention_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="mention_notify" value="Y" checked="checked"|cond="$user_config->mention_notify == 'Y'" /> 사용
+					<input type="radio" name="mention_notify" value="Y" checked="checked"|cond="$user_config->mention_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="mention_notify" value="N" checked="checked"|cond="$user_config->mention_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="mention_notify" value="N" checked="checked"|cond="$user_config->mention_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">누군가 글, 혹은 댓글을 통해서 나를 맨션 했을 경우 알려줍니다. (맨션 방법 @닉네임 )</p>
+				<p class="help-block">{$lang->ncenterlite_mention_noti_about}</p>
 			</div>
 		</div>
 		<div class="control-group">
-			<label class="control-label">쪽지 알림</label>
+			<label class="control-label">{$lang->ncenterlite_message_noti}</label>
 			<div class="controls">
 				<label class="inline">
-					<input type="radio" name="message_notify" value="Y" checked="checked"|cond="$user_config->message_notify == 'Y'" /> 사용
+					<input type="radio" name="message_notify" value="Y" checked="checked"|cond="$user_config->message_notify == 'Y'" /> {$lang->ncenterlite_activate}
 				</label>
 				<label class="inline">
-					<input type="radio" name="message_notify" value="N" checked="checked"|cond="$user_config->message_notify == 'N'" /> 사용 안 함
+					<input type="radio" name="message_notify" value="N" checked="checked"|cond="$user_config->message_notify == 'N'" /> {$lang->ncenterlite_inactivate}
 				</label>
-				<p class="help-block">누군가에게 받은 쪽지를 알림을 받습니다.</p>
+				<p class="help-block">{$lang->ncenterlite_message_noti_about}</p>
 			</div>
 		</div>
 
@@ -61,3 +65,4 @@
 	</div>
 </form>
 </div>
+<include target="../../../member/skins/default/common_footer.html" />


### PR DESCRIPTION
알림센터의 다국어 지원을 개선합니다.

관리자 화면의 다국어 지원은 아직 대부분 되어 있지 않지만, 사이트 이용자 입장의 다국어 지원은 이 PR을 통해서 해결할 수 있습니다.

외국어 중 영어만 할줄 알기 때문에 영어만 적어두었습니다. 다국어를 지원할 수 있도록 언어파일과 그 외 파일을 개선했기 때문에, 번역가 분들의 지원만 있으면 다른 언어도 지원할 수 있습니다.
https://github.com/xe-public/xe-module-ncenterlite/issues/89